### PR TITLE
Upgrade to Serde 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ time = "0.1.35"
 
 [dependencies.serde]
 optional = true
-version = "0.7.0"
+version = "0.8.0"
 
 [dev-dependencies]
-serde_json = "0.7.0"
+serde_json = "0.8.0"
 
 [features]
 

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,50 +1,13 @@
 use serde::{ser, de};
 use super::{Timestamp, WallT};
-use time;
 
 impl<T: ser::Serialize> ser::Serialize for Timestamp<T> {
     fn serialize<S: ser::Serializer>(&self, serializer: &mut S) -> Result<(), S::Error> {
-        struct Visitor<'a, T: ser::Serialize + 'a> {
-            state: usize,
-            value: &'a Timestamp<T>,
-            _structure_ty: ::std::marker::PhantomData<&'a Timestamp<T>>,
-        }
-        impl<'a, T: ser::Serialize + 'a> ser::SeqVisitor for Visitor<'a, T> {
-            #[inline]
-            fn visit<S>(&mut self,
-                        serializer: &mut S)
-                        -> ::std::result::Result<Option<()>, S::Error>
-                where S: ser::Serializer
-            {
-                match self.state {
-                    0usize => {
-                        self.state += 1;
-                        Ok(Some(try!(serializer.serialize_tuple_struct_elt(&self.value.epoch))))
-                    }
-                    1usize => {
-                        self.state += 1;
-                        Ok(Some(try!(serializer.serialize_tuple_struct_elt(&self.value.time))))
-                    }
-                    2usize => {
-                        self.state += 1;
-                        Ok(Some(try!(serializer.serialize_tuple_struct_elt(&self.value.count))))
-                    }
-                    _ => Ok(None),
-                }
-            }
-            #[inline]
-            fn len(&self) -> Option<usize> {
-                Some(3usize)
-            }
-        }
-
-        serializer.serialize_tuple_struct("Timestamp",
-                                          Visitor {
-                                              value: self,
-                                              state: 0,
-                                              _structure_ty:
-                                                  ::std::marker::PhantomData::<&Timestamp<T>>,
-                                          })
+        let mut tuple_state = try!(serializer.serialize_tuple_struct("Timestamp", 3usize));
+        try!(serializer.serialize_tuple_struct_elt(&mut tuple_state, &self.epoch));
+        try!(serializer.serialize_tuple_struct_elt(&mut tuple_state, &self.time));
+        try!(serializer.serialize_tuple_struct_elt(&mut tuple_state, &self.count));
+        return serializer.serialize_tuple_struct_end(tuple_state);
     }
 }
 impl<T: de::Deserialize> de::Deserialize for Timestamp<T> {
@@ -98,38 +61,9 @@ impl<T: de::Deserialize> de::Deserialize for Timestamp<T> {
 
 impl ser::Serialize for WallT {
     fn serialize<S: ser::Serializer>(&self, serializer: &mut S) -> Result<(), S::Error> {
-        struct Visitor<'a> {
-            state: usize,
-            value: &'a WallT,
-            _structure_ty: ::std::marker::PhantomData<&'a WallT>,
-        }
-        impl<'a> ser::SeqVisitor for Visitor<'a> {
-            #[inline]
-            fn visit<S>(&mut self,
-                        serializer: &mut S)
-                        -> ::std::result::Result<Option<()>, S::Error>
-                where S: ser::Serializer
-            {
-                match self.state {
-                    0usize => {
-                        self.state += 1;
-                        Ok(Some(try!(serializer.serialize_tuple_struct_elt(&self.value.0))))
-                    }
-                    _ => Ok(None),
-                }
-            }
-            #[inline]
-            fn len(&self) -> Option<usize> {
-                Some(1usize)
-            }
-        }
-
-        serializer.serialize_tuple_struct("WallT",
-                                          Visitor {
-                                              value: self,
-                                              state: 0,
-                                              _structure_ty: ::std::marker::PhantomData::<&WallT>,
-                                          })
+        let mut tuple_state = try!(serializer.serialize_tuple_struct("WallT", 1usize));
+        try!(serializer.serialize_tuple_struct_elt(&mut tuple_state, &self.0));
+        return serializer.serialize_tuple_struct_end(tuple_state);
     }
 }
 impl de::Deserialize for WallT {


### PR DESCRIPTION
This upgrades hybrid-clocks to use Serde 0.8, which is really useful from a compatibility perspective with other libraries! I had to rewrite the serialiser, but it's simpler and more readable, which is nice.