### PR TITLE
Split out wild detection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl<S: ClockSource> Clock<S> {
     pub fn new(mut src: S) -> Result<Self> {
         let init = src.now()?;
         let clock = Clock {
-            src: src,
+            src,
             last_observed: Timestamp {
                 epoch: 0,
                 time: init,
@@ -132,14 +132,14 @@ impl<S: ClockSource> Clock<S> {
     }
 
     fn do_observe(&mut self, observation: &Timestamp<S::Time>) {
-        let lp = self.last_observed.clone();
+        let lp = self.last_observed;
 
         self.last_observed = match (
             lp.epoch.cmp(&observation.epoch),
             lp.time.cmp(&observation.time),
             lp.count.cmp(&observation.count),
         ) {
-            (Ordering::Less, _, _) | (Ordering::Equal, Ordering::Less, _) => observation.clone(),
+            (Ordering::Less, _, _) | (Ordering::Equal, Ordering::Less, _) => *observation,
             (Ordering::Equal, Ordering::Equal, Ordering::Less) => Timestamp {
                 count: observation.count + 1,
                 ..lp

--- a/src/source/manual.rs
+++ b/src/source/manual.rs
@@ -1,15 +1,18 @@
-use std::cell::Cell;
+use std::{cell::Cell, fmt};
 
 use super::ClockSource;
 use crate::Result;
 
 pub struct ManualClock(Cell<u64>);
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+pub struct ManualT(u64);
 
 impl<'a> ClockSource for ManualClock {
-    type Time = u64;
+    type Time = ManualT;
     type Delta = u64;
     fn now(&mut self) -> Result<Self::Time> {
-        Ok(self.0.get())
+        Ok(self.0.get().into())
     }
 }
 
@@ -19,5 +22,24 @@ impl ManualClock {
     }
     pub fn set_time(&self, t: u64) {
         self.0.set(t)
+    }
+}
+
+impl From<u64> for ManualT {
+    fn from(src: u64) -> Self {
+        ManualT(src)
+    }
+}
+
+impl std::ops::Sub for ManualT {
+    type Output = u64;
+    fn sub(self, other: Self) -> Self::Output {
+        self.0 - other.0
+    }
+}
+
+impl fmt::Display for ManualT {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.0)
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -9,7 +9,7 @@ pub use self::manual::*;
 pub use self::wall_ns::*;
 use crate::Result;
 
-const NANOS_PER_SEC: u64 = 1000_000_000;
+const NANOS_PER_SEC: u64 = 1_000_000_000;
 
 /// Describes the interface that the inner clock source must provide.
 pub trait ClockSource {

--- a/src/source/wall_ms.rs
+++ b/src/source/wall_ms.rs
@@ -20,7 +20,7 @@ impl Timestamp<WallMST> {
         res[0..4].copy_from_slice(&self.epoch.to_be_bytes());
         res[4..12].copy_from_slice(&self.time.0.to_be_bytes());
         res[12..16].copy_from_slice(&self.count.to_be_bytes());
-        return res;
+        res
     }
 
     pub fn from_bytes(bytes: [u8; 16]) -> Self {
@@ -28,9 +28,9 @@ impl Timestamp<WallMST> {
         let nanos = u64::from_be_bytes(bytes[4..12].try_into().unwrap());
         let count = u32::from_be_bytes(bytes[12..16].try_into().unwrap());
         Timestamp {
-            epoch: epoch,
+            epoch,
             time: WallMST(nanos),
-            count: count,
+            count,
         }
     }
 }
@@ -45,7 +45,7 @@ impl WallMST {
         let secs = self.0 / Self::TICKS_PER_SEC;
         let minor_ticks = self.0 % Self::TICKS_PER_SEC;
         let nsecs = minor_ticks * nanos_per_tick;
-        assert!(nsecs < 1000_000_000, "Internal arithmetic error");
+        assert!(nsecs < 1_000_000_000, "Internal arithmetic error");
         Duration::new(secs, nsecs.try_into().expect("internal error"));
 
         let nanos = u128::from(self.0)
@@ -54,9 +54,7 @@ impl WallMST {
             / u128::from(Self::TICKS_PER_SEC);
 
         Ok(Duration::from_nanos(
-            nanos
-                .try_into()
-                .map_err(|_| Error::SupportedTime(nanos.into()))?,
+            nanos.try_into().map_err(|_| Error::SupportedTime(nanos))?,
         ))
     }
 

--- a/src/source/wall_ms.rs
+++ b/src/source/wall_ms.rs
@@ -39,20 +39,17 @@ impl WallMST {
     /// The number of ticks per seconds: 2^(-16).
     pub const TICKS_PER_SEC: u64 = 1 << 16;
     /// Returns the `Duration` since the unix epoch.
-    pub fn duration_since_epoch(self) -> Result<Duration> {
+    pub fn duration_since_epoch(self) -> Duration {
         let secs = self.0 / Self::TICKS_PER_SEC;
         let minor_ticks = self.0 % Self::TICKS_PER_SEC;
         let nsecs = minor_ticks * NANOS_PER_SEC / Self::TICKS_PER_SEC;
         assert!(nsecs < 1_000_000_000, "Internal arithmetic error");
-        Ok(Duration::new(
-            secs,
-            nsecs.try_into().expect("internal error"),
-        ))
+        Duration::new(secs, nsecs.try_into().expect("internal error"))
     }
 
     /// Returns a `SystemTime` representing this timestamp.
-    pub fn as_systemtime(self) -> Result<SystemTime> {
-        Ok(SystemTime::UNIX_EPOCH + self.duration_since_epoch()?)
+    pub fn as_systemtime(self) -> SystemTime {
+        SystemTime::UNIX_EPOCH + self.duration_since_epoch()
     }
 
     /// Returns a `WallMST` representing the `SystemTime`.
@@ -103,26 +100,19 @@ impl ClockSource for WallMS {
 impl fmt::Display for WallMST {
     #[cfg(not(feature = "pretty-print"))]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.duration_since_epoch() {
-            Ok(epoch) => write!(fmt, "{}", epoch.as_secs_f64()),
-            Err(e) => write!(fmt, "{}", e),
-        }
+        write!(fmt, "{}", self.duration_since_epoch().as_secs_f64())
     }
 
     #[cfg(feature = "pretty-print")]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.as_systemtime() {
-            Ok(ts) => {
-                let st = time::PrimitiveDateTime::from(ts);
-                write!(
-                    fmt,
-                    "{}.{:09}Z",
-                    st.format("%Y-%m-%dT%H:%M:%S"),
-                    st.nanosecond(),
-                )
-            }
-            Err(e) => write!(fmt, "{}", e),
-        }
+        let ts = self.as_systemtime();
+        let st = time::PrimitiveDateTime::from(ts);
+        write!(
+            fmt,
+            "{}.{:09}Z",
+            st.format("%Y-%m-%dT%H:%M:%S"),
+            st.nanosecond(),
+        )
     }
 }
 
@@ -155,7 +145,7 @@ mod tests {
         let allowable_error = WallMST::TICKS_PER_SEC / 1000 / 2;
 
         property(wallclocks2()).check(|wc| {
-            let tsp = wc.as_systemtime().expect("wall time");
+            let tsp = wc.as_systemtime();
             let wc2 = WallMST::from_timespec(tsp).expect("from time");
             let diff = wc.0 - wc2.0;
             assert!(
@@ -174,8 +164,8 @@ mod tests {
         property((wallclocks2(), wallclocks2())).check(|(ta, tb)| {
             use std::cmp::Ord;
 
-            let ba = ta.as_systemtime().expect("wall time");
-            let bb = tb.as_systemtime().expect("wall time");
+            let ba = ta.as_systemtime();
+            let bb = tb.as_systemtime();
             ta.cmp(&tb) == ba.cmp(&bb)
         })
     }

--- a/src/source/wall_ns.rs
+++ b/src/source/wall_ns.rs
@@ -85,7 +85,7 @@ impl fmt::Display for WallNST {
 impl Timestamp<WallNST> {
     pub fn write_bytes<W: io::Write>(&self, mut wr: W) -> std::result::Result<(), io::Error> {
         wr.write_all(&self.to_bytes())?;
-        return Ok(());
+        Ok(())
     }
 
     pub fn to_bytes(&self) -> [u8; 16] {
@@ -93,7 +93,7 @@ impl Timestamp<WallNST> {
         res[0..4].copy_from_slice(&self.epoch.to_be_bytes());
         res[4..12].copy_from_slice(&self.time.0.to_be_bytes());
         res[12..16].copy_from_slice(&self.count.to_be_bytes());
-        return res;
+        res
     }
 
     pub fn read_bytes<R: io::Read>(mut r: R) -> std::result::Result<Self, io::Error> {
@@ -107,9 +107,9 @@ impl Timestamp<WallNST> {
         let nanos = u64::from_be_bytes(bytes[4..12].try_into().unwrap());
         let count = u32::from_be_bytes(bytes[12..16].try_into().unwrap());
         Timestamp {
-            epoch: epoch,
+            epoch,
             time: WallNST::of_nanos(nanos),
-            count: count,
+            count,
         }
     }
 }
@@ -126,13 +126,13 @@ pub mod v1 {
 
     impl From<super::WallNST> for WallNST {
         fn from(v2: super::WallNST) -> Self {
-            return WallNST(v2.0);
+            WallNST(v2.0)
         }
     }
 
     impl From<WallNST> for super::WallNST {
         fn from(v1: WallNST) -> super::WallNST {
-            return super::WallNST(v1.0);
+            super::WallNST(v1.0)
         }
     }
 
@@ -140,7 +140,7 @@ pub mod v1 {
         fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
             let mut tuple_state = serializer.serialize_tuple_struct("WallNST", 1usize)?;
             tuple_state.serialize_field(&self.0)?;
-            return tuple_state.end();
+            tuple_state.end()
         }
     }
 
@@ -229,7 +229,6 @@ mod tests {
     #[cfg(feature = "serialization")]
     mod serde {
         use super::*;
-        use serde_json;
         #[test]
         fn should_round_trip_via_serde() {
             property(timestamps(wallclocks_ns())).check(|ts| {

--- a/tests/clocks.rs
+++ b/tests/clocks.rs
@@ -2,7 +2,7 @@ use hybrid_clocks::{Clock, ManualClock, Result, Timestamp};
 use suppositions::generators::*;
 use suppositions::*;
 
-fn observing<'a>(clock: &mut Clock<ManualClock>, msg: &Timestamp<u64>) -> Result<Timestamp<u64>> {
+fn observing(clock: &mut Clock<ManualClock>, msg: &Timestamp<u64>) -> Result<Timestamp<u64>> {
     clock.observe(msg);
     Ok(clock.now()?)
 }
@@ -346,7 +346,7 @@ fn should_use_time_from_larger_observed_epoch() -> Result<()> {
 }
 
 #[test]
-fn supposedly_be_larger_than_observed_time() -> Result<()> {
+fn supposedly_be_larger_than_observed_time() {
     property((u64s(), timestamps(u64s()))).check(|(t0, advanced_epoch)| -> Result<()> {
         let mut clock0 = Clock::manual(t0)?;
         let t2 = observing(&mut clock0, &advanced_epoch).unwrap();
@@ -354,11 +354,10 @@ fn supposedly_be_larger_than_observed_time() -> Result<()> {
         assert!(t2 > advanced_epoch, "{:?} > {:?}", t2, advanced_epoch);
         Ok(())
     });
-    Ok(())
 }
 
 #[test]
-fn supposedly_be_larger_than_observed_clock() -> Result<()> {
+fn supposedly_be_larger_than_observed_clock() {
     property((u64s(), timestamps(u64s()))).check(|(t0, advanced_epoch)| -> Result<()> {
         let mut clock0 = Clock::manual(t0)?;
         let t1 = clock0.now()?;
@@ -367,7 +366,6 @@ fn supposedly_be_larger_than_observed_clock() -> Result<()> {
         assert!(t2 > t1, "{:?} > {:?}", t2, t1);
         Ok(())
     });
-    Ok(())
 }
 
 #[test]
@@ -436,14 +434,13 @@ fn should_observe_past_timestamp() -> Result<()> {
 #[cfg(feature = "serialization")]
 mod serde {
     use super::*;
-    use serde_json;
+
     #[test]
-    fn should_round_trip_via_serde() -> Result<()> {
+    fn should_round_trip_via_serde() {
         property(timestamps(u64s())).check(|ts| {
             let s = serde_json::to_string(&ts).expect("to-json");
             let ts2 = serde_json::from_str(&s).expect("from-json");
             ts == ts2
         });
-        Ok(())
     }
 }

--- a/tests/clocks.rs
+++ b/tests/clocks.rs
@@ -1,8 +1,11 @@
-use hybrid_clocks::{Clock, ManualClock, Result, Timestamp};
+use hybrid_clocks::{Clock, ManualClock, ManualT, Result, Timestamp};
 use suppositions::generators::*;
 use suppositions::*;
 
-fn observing(clock: &mut Clock<ManualClock>, msg: &Timestamp<u64>) -> Result<Timestamp<u64>> {
+fn observing(
+    clock: &mut Clock<ManualClock>,
+    msg: &Timestamp<ManualT>,
+) -> Result<Timestamp<ManualT>> {
     clock.observe(msg);
     Ok(clock.now()?)
 }
@@ -16,6 +19,9 @@ pub fn timestamps<C: Generator + 'static>(
         .map(|(epoch, time, count)| Timestamp { epoch, time, count })
         .boxed()
 }
+pub fn manualts() -> Box<dyn GeneratorObject<Item = ManualT>> {
+    u64s().map(ManualT::from).boxed()
+}
 
 #[test]
 fn fig_6_proc_0_a() -> Result<()> {
@@ -25,7 +31,7 @@ fn fig_6_proc_0_a() -> Result<()> {
         clock.now()?,
         Timestamp {
             epoch: 0,
-            time: 10,
+            time: 10.into(),
             count: 0
         }
     );
@@ -40,14 +46,14 @@ fn fig_6_proc_1_a() -> Result<()> {
             &mut clock,
             &Timestamp {
                 epoch: 0,
-                time: 10,
+                time: 10.into(),
                 count: 0
             }
         )
         .unwrap(),
         Timestamp {
             epoch: 0,
-            time: 10,
+            time: 10.into(),
             count: 1
         }
     );
@@ -61,7 +67,7 @@ fn fig_6_proc_1_b() -> Result<()> {
         &mut clock,
         &Timestamp {
             epoch: 0,
-            time: 10,
+            time: 10.into(),
             count: 0,
         },
     )
@@ -71,7 +77,7 @@ fn fig_6_proc_1_b() -> Result<()> {
         clock.now()?,
         Timestamp {
             epoch: 0,
-            time: 10,
+            time: 10.into(),
             count: 2
         }
     );
@@ -83,7 +89,7 @@ fn fig_6_proc_2_b() -> Result<()> {
     let mut clock = Clock::manual(0)?;
     clock.observe(&Timestamp {
         epoch: 0,
-        time: 1,
+        time: 1.into(),
         count: 0,
     });
 
@@ -93,14 +99,14 @@ fn fig_6_proc_2_b() -> Result<()> {
             &mut clock,
             &Timestamp {
                 epoch: 0,
-                time: 10,
+                time: 10.into(),
                 count: 2
             }
         )
         .unwrap(),
         Timestamp {
             epoch: 0,
-            time: 10,
+            time: 10.into(),
             count: 3
         }
     );
@@ -115,7 +121,7 @@ fn fig_6_proc_2_c() -> Result<()> {
         &mut clock,
         &Timestamp {
             epoch: 0,
-            time: 10,
+            time: 10.into(),
             count: 2,
         },
     )
@@ -125,7 +131,7 @@ fn fig_6_proc_2_c() -> Result<()> {
         clock.now()?,
         Timestamp {
             epoch: 0,
-            time: 10,
+            time: 10.into(),
             count: 4
         }
     );
@@ -137,7 +143,7 @@ fn all_sources_same() -> Result<()> {
     let mut clock = Clock::manual(0)?;
     let observed = Timestamp {
         epoch: 0,
-        time: 0,
+        time: 0.into(),
         count: 5,
     };
     let result = observing(&mut clock, &observed)?;
@@ -156,7 +162,7 @@ fn handles_time_going_backwards_now() -> Result<()> {
         clock.now()?,
         Timestamp {
             epoch: 0,
-            time: 10,
+            time: 10.into(),
             count: 2
         }
     );
@@ -172,13 +178,13 @@ fn handles_time_going_backwards_observe() -> Result<()> {
         &mut clock,
         &Timestamp {
             epoch: 0,
-            time: 0,
+            time: 0.into(),
             count: 0,
         },
     )
     .unwrap();
     assert!(result > original);
-    assert!(result.time == 10);
+    assert!(result.time == 10.into());
     Ok(())
 }
 
@@ -194,7 +200,7 @@ fn handles_time_going_forwards_now() -> Result<()> {
         t2,
         Timestamp {
             epoch: 0,
-            time: 12,
+            time: 12.into(),
             count: 0
         }
     );
@@ -211,14 +217,14 @@ fn handles_time_going_forwards_observe() -> Result<()> {
             &mut clock,
             &Timestamp {
                 epoch: 0,
-                time: 0,
+                time: 0.into(),
                 count: 0
             }
         )
         .unwrap(),
         Timestamp {
             epoch: 0,
-            time: 12,
+            time: 12.into(),
             count: 0
         }
     );
@@ -255,7 +261,7 @@ fn should_apply_configured_epoch() -> Result<()> {
         a,
         Timestamp {
             epoch: 1,
-            time: 1,
+            time: 1.into(),
             count: 0
         }
     );
@@ -283,7 +289,7 @@ fn should_update_via_observed_epochs() -> Result<()> {
         a,
         Timestamp {
             epoch: 1,
-            time: 1,
+            time: 1.into(),
             count: 0
         }
     );
@@ -291,7 +297,7 @@ fn should_update_via_observed_epochs() -> Result<()> {
         b,
         Timestamp {
             epoch: 1,
-            time: 1,
+            time: 1.into(),
             count: 1
         }
     );
@@ -317,7 +323,7 @@ fn should_remember_epochs() -> Result<()> {
         b,
         Timestamp {
             epoch: 1,
-            time: 1,
+            time: 1.into(),
             count: 2
         }
     );
@@ -330,7 +336,7 @@ fn should_use_time_from_larger_observed_epoch() -> Result<()> {
 
     let advanced_epoch = Timestamp {
         epoch: 100,
-        time: 1,
+        time: 1.into(),
         count: 0,
     };
     let t = observing(&mut clock0, &advanced_epoch).unwrap();
@@ -338,7 +344,7 @@ fn should_use_time_from_larger_observed_epoch() -> Result<()> {
         t,
         Timestamp {
             epoch: 100,
-            time: 1,
+            time: 1.into(),
             count: 1
         }
     );
@@ -347,7 +353,7 @@ fn should_use_time_from_larger_observed_epoch() -> Result<()> {
 
 #[test]
 fn supposedly_be_larger_than_observed_time() {
-    property((u64s(), timestamps(u64s()))).check(|(t0, advanced_epoch)| -> Result<()> {
+    property((u64s(), timestamps(manualts()))).check(|(t0, advanced_epoch)| -> Result<()> {
         let mut clock0 = Clock::manual(t0)?;
         let t2 = observing(&mut clock0, &advanced_epoch).unwrap();
         println!("t0: {:?}; 👀: {:?} => {:?}", t0, advanced_epoch, t2);
@@ -358,7 +364,7 @@ fn supposedly_be_larger_than_observed_time() {
 
 #[test]
 fn supposedly_be_larger_than_observed_clock() {
-    property((u64s(), timestamps(u64s()))).check(|(t0, advanced_epoch)| -> Result<()> {
+    property((u64s(), timestamps(manualts()))).check(|(t0, advanced_epoch)| -> Result<()> {
         let mut clock0 = Clock::manual(t0)?;
         let t1 = clock0.now()?;
         let t2 = observing(&mut clock0, &advanced_epoch).unwrap();
@@ -375,7 +381,7 @@ fn should_ignore_clocks_too_far_forward() -> Result<()> {
     assert!(clock
         .observe(&Timestamp {
             epoch: 0,
-            time: 11,
+            time: 11.into(),
             count: 0
         })
         .is_err());
@@ -383,7 +389,7 @@ fn should_ignore_clocks_too_far_forward() -> Result<()> {
     clock
         .observe(&Timestamp {
             epoch: 0,
-            time: 1,
+            time: 1.into(),
             count: 0,
         })
         .unwrap();
@@ -391,7 +397,7 @@ fn should_ignore_clocks_too_far_forward() -> Result<()> {
         clock.now().expect("now"),
         Timestamp {
             epoch: 0,
-            time: 1,
+            time: 1.into(),
             count: 1
         }
     );
@@ -407,7 +413,7 @@ fn should_account_for_time_passing_when_checking_max_error() -> Result<()> {
     assert!(clock
         .observe(&Timestamp {
             epoch: 0,
-            time: 11,
+            time: 11.into(),
             count: 0
         })
         .is_ok());
@@ -424,7 +430,7 @@ fn should_observe_past_timestamp() -> Result<()> {
     assert!(clock
         .observe(&Timestamp {
             epoch: 0,
-            time: 9,
+            time: 9.into(),
             count: 0
         })
         .is_ok());
@@ -437,7 +443,7 @@ mod serde {
 
     #[test]
     fn should_round_trip_via_serde() {
-        property(timestamps(u64s())).check(|ts| {
+        property(timestamps(manualts())).check(|ts| {
             let s = serde_json::to_string(&ts).expect("to-json");
             let ts2 = serde_json::from_str(&s).expect("from-json");
             ts == ts2


### PR DESCRIPTION
The theory here is that we abstract a trait over Clocks like this:

```rust
trait Clocks {
   type Timestamp;
   type Error;
   fn observe(&mut self, &Self::Timestamp) -> Result<(), Self::Error>;
   fn now(&mut self) -> Result<Self::Timestamp, Self::Error>;
}
```

